### PR TITLE
Adding new setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,5 +82,5 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 ## xvfb python-opengl \
 ###################################
 
-RUN pip install --upgrade pip && \
-    pip3 install --upgrade pip
+RUN pip install --upgrade pip setuptools wheel && \
+    pip3 install --upgrade pip setuptools wheel


### PR DESCRIPTION
The version of setup tools in the container is too old to build several of the packages in ml_platform; this adds an update to setup tools. And wheel, just to be safe.